### PR TITLE
Create brave-search.config

### DIFF
--- a/mcp-servers/brave-search.config
+++ b/mcp-servers/brave-search.config
@@ -11,41 +11,11 @@
     "iconUrl": "https://brave.com/static-assets/images/brave-logo-sans-text.svg",
     "documentation": "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search"
   },
-  "source": {
-    "repository": {
-      "type": "git",
-      "url": "",
-      "branch": "main",
-      "tag": "v1.0.0",
-      "auth": {
-        "type": "",
-        "sshKeySecret": ""
-      }
-    },
-    "build": {
-      "context": ".",
-      "dockerfile": "",
-      "args": {
-        "PYTHON_VERSION": ""
-      }
-    },
-    "registry": {
-      "url": "",
-      "auth": {
-        "type": "token",
-        "secretName": ""
-      }
-    }
-  },
   "runtime": {
-    "language": {
-      "name": "npx",
-      "version": ""
-    },
     "baseImage": {
-      "repository": "",
-      "tag": "",
-      "registry": ""
+      "repository": "python",
+      "tag": "3.9-slim",
+      "registry": "docker.io"
     },
     "command": "npx",
     "args": [
@@ -56,61 +26,43 @@
       "BRAVE_API_KEY": "{{installConfig.BRAVE_API_KEY}}"
     },
     "alwaysAllow": true,
-    "disabled": false,
-    "dependencies": {
-      "python": {
-        "openai": "^1.0.0",
-        "pydantic": "^2.0.0",
-        "fastapi": "^0.100.0"
-      },
-      "system": {
-        "memory": "512Mi",
-        "cpu": "0.5"
-      }
-    }
+    "disabled": false
   },
   "installConfig": {
-    "required": {
-      "BRAVE_API_KEY": {
-        "type": "string",
-        "label": "Brave API 金鑰",
-        "description": "Please input your Brave API key",
-        "validation": {
-          "pattern": "^sk-[A-Za-z0-9]{48}$",
-          "message": "Please input valid Brave API format"
-        }
-      }
+    "BRAVE_API_KEY": {
+      "type": "string",
+      "label": "Brave API 金鑰",
+      "description": "Please input your Brave API key",
+      "required": true
     },
-    "advanced": {
-      "apiEndpoint": {
-        "type": "string",
-        "label": "API 端點",
-        "description": "自訂 API 端點（選填）",
-        "default": "https://api.openai.com/v1",
-        "required": false
+    "apiEndpoint": {
+      "type": "string",
+      "label": "API 端點",
+      "description": "自訂 API 端點（選填）",
+      "default": "https://api.openai.com/v1",
+      "required": false
+    },
+    "maxTokens": {
+      "type": "number",
+      "label": "最大 Token 數",
+      "description": "單次請求的最大 Token 限制",
+      "default": 4096,
+      "validation": {
+        "min": 1,
+        "max": 8192
       },
-      "maxTokens": {
-        "type": "number",
-        "label": "最大 Token 數",
-        "description": "單次請求的最大 Token 限制",
-        "default": 4096,
-        "validation": {
-          "min": 1,
-          "max": 8192
-        },
-        "required": false
+      "required": false
+    },
+    "timeout": {
+      "type": "number",
+      "label": "請求逾時時間",
+      "description": "API 請求逾時時間（秒）",
+      "default": 30,
+      "validation": {
+        "min": 1,
+        "max": 300
       },
-      "timeout": {
-        "type": "number",
-        "label": "請求逾時時間",
-        "description": "API 請求逾時時間（秒）",
-        "default": 30,
-        "validation": {
-          "min": 1,
-          "max": 300
-        },
-        "required": false
-      }
+      "required": false
     }
-  }
+  },
 }

--- a/mcp-servers/brave-search.config
+++ b/mcp-servers/brave-search.config
@@ -1,0 +1,116 @@
+{
+  "marketplace": {
+    "name": "Brave Search",
+    "description": "This MCP Server is from Github @modelcontextprotocol. Brave Search MCP Server intergrate with Brave Search API, now your LLM is able to search the keyword.",
+    "version": "1.0.0",
+    "maintainer": {
+      "name": "AI Operator Team",
+      "email": "eric.shen@pentium.network"
+    },
+    "tags": ["AI", "OpenAI", "GPT", "LLM"],
+    "iconUrl": "https://brave.com/static-assets/images/brave-logo-sans-text.svg",
+    "documentation": "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search"
+  },
+  "source": {
+    "repository": {
+      "type": "git",
+      "url": "",
+      "branch": "main",
+      "tag": "v1.0.0",
+      "auth": {
+        "type": "",
+        "sshKeySecret": ""
+      }
+    },
+    "build": {
+      "context": ".",
+      "dockerfile": "",
+      "args": {
+        "PYTHON_VERSION": ""
+      }
+    },
+    "registry": {
+      "url": "",
+      "auth": {
+        "type": "token",
+        "secretName": ""
+      }
+    }
+  },
+  "runtime": {
+    "language": {
+      "name": "npx",
+      "version": ""
+    },
+    "baseImage": {
+      "repository": "",
+      "tag": "",
+      "registry": ""
+    },
+    "command": "npx",
+    "args": [
+      "-y",
+      "@modelcontextprotocol/server-brave-search"
+    ],
+    "envs": {
+      "BRAVE_API_KEY": "{{installConfig.BRAVE_API_KEY}}"
+    },
+    "alwaysAllow": true,
+    "disabled": false,
+    "dependencies": {
+      "python": {
+        "openai": "^1.0.0",
+        "pydantic": "^2.0.0",
+        "fastapi": "^0.100.0"
+      },
+      "system": {
+        "memory": "512Mi",
+        "cpu": "0.5"
+      }
+    }
+  },
+  "installConfig": {
+    "required": {
+      "BRAVE_API_KEY": {
+        "type": "string",
+        "label": "Brave API 金鑰",
+        "description": "Please input your Brave API key",
+        "validation": {
+          "pattern": "^sk-[A-Za-z0-9]{48}$",
+          "message": "Please input valid Brave API format"
+        }
+      }
+    },
+    "advanced": {
+      "apiEndpoint": {
+        "type": "string",
+        "label": "API 端點",
+        "description": "自訂 API 端點（選填）",
+        "default": "https://api.openai.com/v1",
+        "required": false
+      },
+      "maxTokens": {
+        "type": "number",
+        "label": "最大 Token 數",
+        "description": "單次請求的最大 Token 限制",
+        "default": 4096,
+        "validation": {
+          "min": 1,
+          "max": 8192
+        },
+        "required": false
+      },
+      "timeout": {
+        "type": "number",
+        "label": "請求逾時時間",
+        "description": "API 請求逾時時間（秒）",
+        "default": 30,
+        "validation": {
+          "min": 1,
+          "max": 300
+        },
+        "required": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
貼上我在 Roo Code 中可以使用的 mcp config

"brave-search-npx": {
      "command": "npx",
      "args": [
        "-y",
        "@modelcontextprotocol/server-brave-search"
      ],
      "env": {
        "BRAVE_API_KEY": "my_brave_key"
      }
    }